### PR TITLE
feat: Add workspace feature with drag-and-drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "@tanstack/react-query": "^5.81.5",
     "@tanstack/react-query-devtools": "^5.81.5",
     "framer-motion": "^12.16.0",
+    "lucide-react": "^0.541.0",
     "react": "^19.1.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2"
   },

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -73,6 +73,12 @@ export const Header = () => {
         >
           팀원 탐색
         </Link>
+        <Link
+          to="/workspace"
+          className={isActive("/workspace") ? "text-blue-600" : "text-black"}
+        >
+          워크스페이스
+        </Link>
         {userId && (
           <Link
             to="/mypage"

--- a/src/components/atoms/Avatar.tsx
+++ b/src/components/atoms/Avatar.tsx
@@ -1,0 +1,91 @@
+// 표준 라이브러리
+import { ReactNode } from "react";
+
+// Avatar 크기 타입
+type AvatarSize = "sm" | "md" | "lg" | "xl";
+
+/**
+ * Avatar 컴포넌트의 Props 타입
+ */
+interface AvatarProps {
+  /** 아바타 이미지 URL */
+  src?: string;
+  /** 대체 텍스트 */
+  alt?: string;
+  /** 크기 */
+  size?: AvatarSize;
+  /** 추가 CSS 클래스 */
+  className?: string;
+  /** Fallback 컴포넌트 */
+  children?: ReactNode;
+}
+
+/**
+ * AvatarFallback 컴포넌트의 Props 타입
+ */
+interface AvatarFallbackProps {
+  /** Fallback 내용 */
+  children: ReactNode;
+  /** 추가 CSS 클래스 */
+  className?: string;
+}
+
+/**
+ * Avatar 컴포넌트
+ * 사용자 프로필 이미지를 표시합니다.
+ */
+export const Avatar = ({ 
+  src, 
+  alt = "Avatar", 
+  size = "md", 
+  className = "", 
+  children 
+}: AvatarProps) => {
+  // 크기별 스타일
+  const sizeClasses: Record<AvatarSize, string> = {
+    sm: "h-6 w-6",
+    md: "h-8 w-8",
+    lg: "h-10 w-10",
+    xl: "h-12 w-12",
+  };
+
+  const baseClass = "inline-block rounded-full overflow-hidden bg-gray-100";
+  const sizeClass = sizeClasses[size];
+  const finalClassName = `${baseClass} ${sizeClass} ${className}`.trim();
+
+  if (src) {
+    return (
+      <div className={finalClassName}>
+        <img
+          src={src}
+          alt={alt}
+          className="h-full w-full object-cover"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={finalClassName}>
+      {children}
+    </div>
+  );
+};
+
+/**
+ * AvatarFallback 컴포넌트
+ * Avatar 이미지가 없을 때 표시되는 fallback입니다.
+ */
+export const AvatarFallback = ({ 
+  children, 
+  className = "" 
+}: AvatarFallbackProps) => {
+  const baseClass = "h-full w-full flex items-center justify-center bg-gray-100 text-gray-600 font-medium";
+  const finalClassName = `${baseClass} ${className}`.trim();
+
+  return (
+    <div className={finalClassName}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/atoms/Card.tsx
+++ b/src/components/atoms/Card.tsx
@@ -1,0 +1,74 @@
+// 표준 라이브러리
+import { ReactNode, forwardRef } from "react";
+
+/**
+ * Card 컴포넌트의 Props 타입
+ */
+interface CardProps {
+  /** Card 내용 */
+  children: ReactNode;
+  /** 추가 CSS 클래스 */
+  className?: string;
+  /** 클릭 이벤트 핸들러 */
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  /** 접근성을 위한 role 속성 */
+  role?: string;
+  /** 접근성을 위한 tabIndex */
+  tabIndex?: number;
+  /** 접근성을 위한 aria-label */
+  "aria-label"?: string;
+  /** 키보드 이벤트 핸들러 */
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+}
+
+/**
+ * CardContent 컴포넌트의 Props 타입
+ */
+interface CardContentProps {
+  /** Content 내용 */
+  children: ReactNode;
+  /** 추가 CSS 클래스 */
+  className?: string;
+}
+
+/**
+ * Card 컴포넌트
+ * 컨텐츠를 그룹화하여 표시하는 컨테이너입니다.
+ */
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ children, className = "", onClick, onKeyDown, ...props }, ref) => {
+    const baseClass = "bg-white rounded-lg border border-gray-200 shadow-sm";
+    const clickableClass = onClick ? "cursor-pointer transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" : "";
+    
+    const finalClassName = `${baseClass} ${clickableClass} ${className}`.trim();
+
+    return (
+      <div 
+        ref={ref}
+        className={finalClassName}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+Card.displayName = "Card";
+
+/**
+ * CardContent 컴포넌트
+ * Card 내부의 콘텐츠 영역입니다.
+ */
+export const CardContent = ({ children, className = "" }: CardContentProps) => {
+  const baseClass = "p-6";
+  const finalClassName = `${baseClass} ${className}`.trim();
+
+  return (
+    <div className={finalClassName}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/workspace/CalendarView.tsx
+++ b/src/components/workspace/CalendarView.tsx
@@ -1,0 +1,16 @@
+/**
+ * 캘린더 뷰 컴포넌트
+ * 태스크를 캘린더 형태로 표시합니다.
+ */
+export function CalendarView() {
+  return (
+    <div className="flex-1 p-6 bg-gray-50">
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+        <div className="text-center">
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">Calendar View</h2>
+          <p className="text-gray-600">캘린더 뷰는 곧 추가될 예정입니다.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/DocumentsView.tsx
+++ b/src/components/workspace/DocumentsView.tsx
@@ -1,0 +1,16 @@
+/**
+ * 문서 뷰 컴포넌트
+ * 프로젝트 관련 문서들을 관리합니다.
+ */
+export function DocumentsView() {
+  return (
+    <div className="flex-1 p-6 bg-gray-50">
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+        <div className="text-center">
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">Documents</h2>
+          <p className="text-gray-600">문서 관리 기능은 곧 추가될 예정입니다.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/KanbanBoard.tsx
+++ b/src/components/workspace/KanbanBoard.tsx
@@ -1,0 +1,186 @@
+// 표준 라이브러리
+import { useState } from "react";
+
+// 서드파티 라이브러리
+import { useDrop } from "react-dnd";
+import { Plus } from "lucide-react";
+
+// 내부 모듈
+import { KanbanCard } from "./KanbanCard";
+import type { KanbanCardProps, TaskStatus } from "./KanbanCard";
+import { Button } from "@/components/atoms/Button";
+
+/**
+ * 칸반 보드 컴포넌트의 Props 타입
+ */
+interface KanbanBoardProps {
+  /** 태스크 선택 핸들러 */
+  onTaskSelect: (task: KanbanCardProps) => void;
+  /** 새 태스크 생성 핸들러 */
+  onNewTask: (columnId: TaskStatus) => void;
+  /** 칸반 태스크 데이터 */
+  tasks: Record<string, KanbanCardProps[]>;
+  /** 태스크 이동 핸들러 */
+  onTaskMove: (taskId: string, newStatus: TaskStatus) => void;
+}
+
+/**
+ * 칸반 컬럼 컴포넌트의 Props 타입
+ */
+interface ColumnProps {
+  /** 컬럼 ID */
+  id: TaskStatus;
+  /** 컬럼 제목 */
+  title: string;
+  /** 컬럼에 속한 태스크 목록 */
+  tasks: KanbanCardProps[];
+  /** 헤더 색상 클래스 */
+  headerColor: string;
+  /** 제목 색상 클래스 */
+  titleColor: string;
+  /** 태스크 선택 핸들러 */
+  onTaskSelect: (task: KanbanCardProps) => void;
+  /** 새 태스크 생성 핸들러 */
+  onNewTask: (columnId: TaskStatus) => void;
+  /** 태스크 이동 핸들러 */
+  onTaskMove: (taskId: string, newStatus: TaskStatus) => void;
+}
+
+function KanbanColumn({ 
+  id, 
+  title, 
+  tasks, 
+  headerColor, 
+  titleColor, 
+  onTaskSelect, 
+  onNewTask,
+  onTaskMove 
+}: ColumnProps) {
+  const [{ isOver }, drop] = useDrop(() => ({
+    accept: 'task',
+    drop: (item: { id: string; status: string }) => {
+      if (item.status !== id) {
+        onTaskMove(item.id, id);
+      }
+    },
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+    }),
+  }));
+
+  return (
+    <section
+      className="flex-shrink-0 w-80"
+      aria-labelledby={`column-${id}-title`}
+    >
+      <div 
+        ref={drop}
+        className={`bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden ${isOver ? 'ring-2 ring-blue-200' : ''} transition-all`}
+      >
+        <header className={`p-4 ${headerColor}`}>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-2">
+              <h3 className={`font-semibold ${titleColor}`} id={`column-${id}-title`}>
+                {title}
+              </h3>
+              <span 
+                className="bg-white/80 text-gray-600 text-xs px-2 py-1 rounded-full font-medium"
+                aria-label={`${tasks.length} tasks`}
+              >
+                {tasks.length}
+              </span>
+            </div>
+            <Button 
+              size="sm" 
+              variant="ghost" 
+              className="h-8 w-8 p-0"
+              onClick={() => onNewTask(id)}
+              aria-label={`Add new task to ${title} column`}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+        </header>
+        
+        <main 
+          className="p-4 space-y-3 min-h-[500px] bg-gray-50/50"
+          role="list"
+          aria-labelledby={`column-${id}-title`}
+        >
+          {tasks.map((task) => (
+            <div key={task.id} role="listitem">
+              <KanbanCard 
+                {...task} 
+                onClick={onTaskSelect}
+              />
+            </div>
+          ))}
+          
+          <Button 
+            variant="outline" 
+            className="w-full h-12 border-2 border-dashed border-gray-300 text-gray-500 bg-white hover:border-gray-400"
+            onClick={() => onNewTask(id)}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Add new task
+          </Button>
+        </main>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * 칸반 보드 컴포넌트
+ * 태스크를 To Do, In Progress, Done 컬럼으로 관리합니다.
+ */
+export function KanbanBoard({ onTaskSelect, onNewTask, tasks, onTaskMove }: KanbanBoardProps) {
+  const COLUMN_CONFIGS = [
+    { 
+      id: "todo" as TaskStatus, 
+      title: "To Do", 
+      tasks: tasks.todo || [],
+      headerColor: "bg-red-50 border-t-4 border-t-red-400",
+      titleColor: "text-red-700"
+    },
+    { 
+      id: "inprogress" as TaskStatus, 
+      title: "In Progress", 
+      tasks: tasks.inprogress || [],
+      headerColor: "bg-yellow-50 border-t-4 border-t-yellow-400",
+      titleColor: "text-yellow-700"
+    },
+    { 
+      id: "done" as TaskStatus, 
+      title: "Done", 
+      tasks: tasks.done || [],
+      headerColor: "bg-green-50 border-t-4 border-t-green-400",
+      titleColor: "text-green-700"
+    }
+  ] as const;
+
+  return (
+    <div className="flex-1 p-6 overflow-x-auto bg-gray-50">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold mb-2 text-gray-900">Kanban Board</h1>
+        <p className="text-gray-600">Manage your tasks and track progress</p>
+      </header>
+      
+      <div 
+        className="flex space-x-6 min-w-max"
+        role="application"
+        aria-label="Kanban board for task management"
+      >
+        {COLUMN_CONFIGS.map((column) => (
+          <KanbanColumn
+            key={column.id}
+            {...column}
+            onTaskSelect={onTaskSelect}
+            onNewTask={onNewTask}
+            onTaskMove={onTaskMove}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/KanbanCard.tsx
+++ b/src/components/workspace/KanbanCard.tsx
@@ -1,0 +1,160 @@
+// 서드파티 라이브러리
+import { useDrag } from "react-dnd";
+import { Calendar, User, GripVertical } from "lucide-react";
+
+// 내부 UI 컴포넌트
+import { Card, CardContent } from "@/components/atoms/Card";
+import { WorkspaceBadge } from "./WorkspaceBadge";
+import { Avatar, AvatarFallback } from "@/components/atoms/Avatar";
+
+// 우선순위 타입 정의
+export type TaskPriority = "high" | "medium" | "low";
+
+// 태스크 상태 타입 정의
+export type TaskStatus = "todo" | "inprogress" | "done";
+
+// 담당자 정보 타입
+export interface TaskAssignee {
+  /** 담당자 이름 */
+  name: string;
+  /** 담당자 아바타 URL (선택사항) */
+  avatar?: string;
+}
+
+/**
+ * 칸반 카드 컴포넌트의 Props 타입
+ */
+export interface KanbanCardProps {
+  /** 태스크 고유 ID */
+  id: string;
+  /** 태스크 제목 */
+  title: string;
+  /** 태스크 설명 (선택사항) */
+  description?: string;
+  /** 태스크 우선순위 */
+  priority: TaskPriority;
+  /** 태스크 상태 */
+  status: TaskStatus;
+  /** 태스크 담당자 */
+  assignee: TaskAssignee;
+  /** 마감일 (YYYY-MM-DD 형식) */
+  dueDate: string;
+  /** 시작일 (YYYY-MM-DD 형식, 선택사항) */
+  startDate?: string;
+  /** 카드 클릭 이벤트 핸들러 */
+  onClick: (task: KanbanCardProps) => void;
+}
+
+/**
+ * 칸반 카드 컴포넌트
+ * 태스크 정보를 카드 형태로 표시하고 드래그 앤 드롭을 지원합니다.
+ */
+export function KanbanCard({ 
+  id,
+  title, 
+  description, 
+  priority, 
+  status,
+  assignee, 
+  dueDate,
+  startDate,
+  onClick
+}: KanbanCardProps) {
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: 'task',
+    item: { id, status },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging(),
+    }),
+  }));
+
+  // Badge 색상 맵핑
+  const PRIORITY_COLOR_MAP: Record<TaskPriority, "red" | "yellow" | "green"> = {
+    high: "red",
+    medium: "yellow",
+    low: "green",
+  } as const;
+
+  const task = {
+    id,
+    title,
+    description,
+    priority,
+    status,
+    assignee,
+    dueDate,
+    startDate,
+    onClick
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onClick(task);
+  };
+
+  return (
+    <Card 
+      ref={drag}
+      className={`mb-3 hover:shadow-md transition-all duration-200 cursor-pointer hover:border-blue-300 bg-white group ${
+        isDragging ? 'opacity-50 rotate-2 shadow-lg' : ''
+      }`} 
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      aria-label={`Task: ${title}. Priority: ${priority}. Assigned to: ${assignee.name}. Due: ${dueDate}`}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick(e as any);
+        }
+      }}
+    >
+      <CardContent className="p-4">
+        <div className="space-y-3">
+          {/* Drag Handle & Title */}
+          <div className="flex items-start space-x-2">
+            <GripVertical 
+              className="h-4 w-4 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 mt-0.5" 
+              aria-hidden="true"
+            />
+            <h4 className="font-medium text-gray-900 leading-tight flex-1">{title}</h4>
+          </div>
+
+          {/* Priority Badge */}
+          <div>
+            <WorkspaceBadge 
+              variant="outline" 
+              size="sm"
+              color={PRIORITY_COLOR_MAP[priority]}
+            >
+              {priority.charAt(0).toUpperCase() + priority.slice(1)}
+            </WorkspaceBadge>
+          </div>
+
+          {/* Due Date */}
+          <div className="flex items-center space-x-2 text-sm text-gray-600">
+            <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+            <time dateTime={dueDate}>Due {dueDate}</time>
+          </div>
+
+          {/* Assignee */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-2 text-sm text-gray-600">
+              <User className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>{assignee.name}</span>
+            </div>
+            
+            <Avatar size="md">
+              <AvatarFallback className="text-xs bg-blue-50 text-blue-600">
+                {assignee.name ? 
+                  assignee.name.split(' ').map(n => n[0]).join('').toUpperCase() : 
+                  '?'
+                }
+              </AvatarFallback>
+            </Avatar>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/workspace/TaskDetail.tsx
+++ b/src/components/workspace/TaskDetail.tsx
@@ -1,0 +1,80 @@
+// 내부 타입
+import type { KanbanCardProps } from "./KanbanCard";
+
+/**
+ * 태스크 상세 컴포넌트의 Props 타입
+ */
+interface TaskDetailProps {
+  /** 표시할 태스크 (새 태스크인 경우 null) */
+  task: KanbanCardProps | null;
+  /** 전체 화면 확장 여부 */
+  isExpanded: boolean;
+  /** 새 태스크 생성 모드 여부 */
+  isNewTask: boolean;
+  /** 닫기 이벤트 핸들러 */
+  onClose: () => void;
+  /** 확장/축소 이벤트 핸들러 */
+  onExpand: () => void;
+  /** 저장 이벤트 핸들러 */
+  onSave: (task: KanbanCardProps) => void;
+  /** 상태 변경 이벤트 핸들러 */
+  onStatusChange: (taskId: string, newStatus: "todo" | "inprogress" | "done") => void;
+}
+
+/**
+ * 태스크 상세 정보 컴포넌트
+ * 태스크의 상세 정보를 표시하고 편집할 수 있는 패널입니다.
+ */
+export function TaskDetail({ 
+  task, 
+  isExpanded, 
+  isNewTask, 
+  onClose, 
+  onExpand, 
+  onSave,
+  onStatusChange 
+}: TaskDetailProps) {
+  if (!task && !isNewTask) return null;
+
+  return (
+    <div className={`${isExpanded ? 'fixed inset-0 z-50 bg-white' : 'w-[480px]'} h-full ${!isExpanded ? 'border-l border-gray-200' : ''} flex flex-col`}>
+      {/* Header */}
+      <header className="p-6 border-b border-gray-100">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {isNewTask ? 'New Task' : 'Task Details'}
+          </h2>
+          <div className="flex space-x-2">
+            <button 
+              onClick={onExpand}
+              className="p-2 hover:bg-gray-100 rounded-md"
+              aria-label={isExpanded ? "Minimize" : "Expand"}
+            >
+              {isExpanded ? "↙" : "↗"}
+            </button>
+            <button 
+              onClick={onClose}
+              className="p-2 hover:bg-gray-100 rounded-md"
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="flex-1 p-6 overflow-y-auto">
+        <div className="bg-gray-50 rounded-lg p-8 text-center">
+          <h3 className="text-lg font-medium text-gray-900 mb-2">Task Detail Panel</h3>
+          <p className="text-gray-600">
+            {task ? `Selected task: ${task.title}` : "Creating new task"}
+          </p>
+          <p className="text-sm text-gray-500 mt-2">
+            태스크 상세 편집 기능은 곧 추가될 예정입니다.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/workspace/WorkspaceBadge.tsx
+++ b/src/components/workspace/WorkspaceBadge.tsx
@@ -1,0 +1,103 @@
+// 표준 라이브러리
+import { ReactNode } from "react";
+
+// Badge 색상 타입
+type BadgeColor = "gray" | "blue" | "red" | "green" | "yellow" | "purple" | "pink";
+
+// Badge variant 타입
+type BadgeVariant = "solid" | "outline";
+
+// Badge 크기 타입
+type BadgeSize = "sm" | "md" | "lg";
+
+/**
+ * Badge 컴포넌트의 Props 타입
+ */
+interface WorkspaceBadgeProps {
+  /** Badge 내용 */
+  children: ReactNode;
+  /** Badge 색상 */
+  color?: BadgeColor;
+  /** Badge variant */
+  variant?: BadgeVariant;
+  /** Badge 크기 */
+  size?: BadgeSize;
+  /** 추가 CSS 클래스 */
+  className?: string;
+  /** 클릭 이벤트 핸들러 */
+  onClick?: (e: React.MouseEvent) => void;
+}
+
+/**
+ * Workspace Badge 컴포넌트
+ * 상태나 카테고리를 표시하는 작은 레이블입니다.
+ */
+export const WorkspaceBadge = ({
+  children,
+  color = "gray",
+  variant = "solid",
+  size = "md",
+  className = "",
+  onClick,
+}: WorkspaceBadgeProps) => {
+  // 기본 스타일
+  const baseClass = "inline-flex items-center font-medium rounded-full transition-colors";
+  const clickableClass = onClick ? "cursor-pointer hover:opacity-80" : "";
+
+  // 크기별 스타일
+  const sizeClasses: Record<BadgeSize, string> = {
+    sm: "px-2 py-0.5 text-xs",
+    md: "px-2.5 py-1 text-sm",
+    lg: "px-3 py-1.5 text-sm",
+  };
+
+  // Variant별 색상 스타일
+  const getVariantClasses = (color: BadgeColor, variant: BadgeVariant): string => {
+    if (variant === "outline") {
+      const outlineClasses: Record<BadgeColor, string> = {
+        gray: "bg-white border border-gray-200 text-gray-800",
+        blue: "bg-blue-50 border border-blue-200 text-blue-800",
+        red: "bg-red-50 border border-red-200 text-red-800",
+        green: "bg-green-50 border border-green-200 text-green-800",
+        yellow: "bg-yellow-50 border border-yellow-200 text-yellow-800",
+        purple: "bg-purple-50 border border-purple-200 text-purple-800",
+        pink: "bg-pink-50 border border-pink-200 text-pink-800",
+      };
+      return outlineClasses[color];
+    }
+    
+    // solid variant (default)
+    const solidClasses: Record<BadgeColor, string> = {
+      gray: "bg-gray-100 text-gray-800",
+      blue: "bg-blue-100 text-blue-800",
+      red: "bg-red-100 text-red-800",
+      green: "bg-green-100 text-green-800",
+      yellow: "bg-yellow-100 text-yellow-800",
+      purple: "bg-purple-100 text-purple-800",
+      pink: "bg-pink-100 text-pink-800",
+    };
+    return solidClasses[color];
+  };
+
+  const variantClass = getVariantClasses(color, variant);
+  const sizeClass = sizeClasses[size];
+  
+  const finalClassName = `${baseClass} ${sizeClass} ${variantClass} ${clickableClass} ${className}`.trim();
+
+  if (onClick) {
+    return (
+      <button
+        className={finalClassName}
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <span className={finalClassName}>
+      {children}
+    </span>
+  );
+};

--- a/src/components/workspace/WorkspaceSidebar.tsx
+++ b/src/components/workspace/WorkspaceSidebar.tsx
@@ -1,0 +1,74 @@
+// 표준 라이브러리
+import { useState } from "react";
+
+// 서드파티 라이브러리
+import { Calendar, FileText, Trello } from "lucide-react";
+
+// 내부 UI 컴포넌트
+import { Button } from "@/components/atoms/Button";
+
+// 뷰 타입 정의
+type ViewType = "kanban" | "calendar" | "documents";
+
+/**
+ * 워크스페이스 사이드바 컴포넌트의 Props 타입
+ */
+interface WorkspaceSidebarProps {
+  /** 현재 활성 뷰 */
+  activeView: ViewType;
+  /** 뷰 변경 이벤트 핸들러 */
+  onViewChange: (view: ViewType) => void;
+}
+
+/**
+ * 워크스페이스 사이드바 컴포넌트
+ * 워크스페이스 내 다양한 뷰 간 네비게이션을 제공합니다.
+ */
+export function WorkspaceSidebar({ activeView, onViewChange }: WorkspaceSidebarProps) {
+  // 네비게이션 메뉴 항목
+  const NAVIGATION_ITEMS = [
+    { id: "kanban" as const, label: "Kanban Board", icon: Trello },
+    { id: "calendar" as const, label: "Calendar", icon: Calendar },
+    { id: "documents" as const, label: "Documents", icon: FileText },
+  ] as const;
+
+  return (
+    <aside 
+      className="w-64 h-full bg-white border-r border-gray-200 flex flex-col"
+      role="navigation"
+      aria-label="Workspace navigation"
+    >
+      {/* Header */}
+      <header className="p-6 border-b border-gray-100">
+        <h1 className="text-xl font-semibold text-gray-900">Workspace</h1>
+        <p className="text-sm text-gray-600 mt-1">Project Management</p>
+      </header>
+
+      {/* Navigation */}
+      <nav className="flex-1 p-4">
+        <div className="space-y-1">
+          {NAVIGATION_ITEMS.map((item) => {
+            const Icon = item.icon;
+            const isActive = activeView === item.id;
+            
+            return (
+              <Button
+                key={item.id}
+                variant="ghost"
+                className={`w-full justify-start h-10 font-normal ${
+                  isActive 
+                    ? "bg-blue-50 text-blue-600 hover:bg-blue-100" 
+                    : "text-gray-700 hover:bg-gray-100"
+                }`}
+                onClick={() => onViewChange(item.id)}
+              >
+                <Icon className="h-4 w-4 mr-3" />
+                {item.label}
+              </Button>
+            );
+          })}
+        </div>
+      </nav>
+    </aside>
+  );
+}

--- a/src/hooks/workspace/useTaskManagement.ts
+++ b/src/hooks/workspace/useTaskManagement.ts
@@ -1,0 +1,121 @@
+// 표준 라이브러리
+import { useState, useCallback } from "react";
+
+// 내부 타입
+import type { KanbanCardProps, TaskStatus } from "@/components/workspace/KanbanCard";
+
+// 초기 태스크 데이터
+const INITIAL_TASKS: Record<string, KanbanCardProps[]> = {
+  todo: [
+    {
+      id: "1",
+      title: "Research competitive analysis",
+      description: "Analyze top 5 competitors and their pricing strategies to understand market positioning and identify opportunities for differentiation.",
+      priority: "high",
+      status: "todo",
+      assignee: { name: "Alice Johnson" },
+      dueDate: "2024-08-25",
+      startDate: "2024-08-20",
+      onClick: () => {}
+    },
+    {
+      id: "2",
+      title: "Design system documentation",
+      description: "Create comprehensive documentation for the design system components including usage guidelines, code examples, and best practices.",
+      priority: "medium",
+      status: "todo",
+      assignee: { name: "Bob Smith" },
+      dueDate: "2024-08-28",
+      startDate: "2024-08-22",
+      onClick: () => {}
+    },
+  ],
+  inprogress: [
+    {
+      id: "4",
+      title: "Homepage redesign",
+      description: "Redesign the homepage with new branding guidelines, improved user flow, and better conversion optimization.",
+      priority: "high",
+      status: "inprogress",
+      assignee: { name: "David Wilson" },
+      dueDate: "2024-08-22",
+      startDate: "2024-08-15",
+      onClick: () => {}
+    },
+  ],
+  done: [
+    {
+      id: "6",
+      title: "Brand guidelines update",
+      description: "Updated comprehensive brand guidelines including new color palette, typography system, and logo usage guidelines.",
+      priority: "medium",
+      status: "done",
+      assignee: { name: "Frank Miller" },
+      dueDate: "2024-08-15",
+      startDate: "2024-08-10",
+      onClick: () => {}
+    },
+  ]
+};
+
+/**
+ * 태스크 관리 커스텀 훅
+ * 태스크의 생성, 수정, 이동 등의 비즈니스 로직을 관리합니다.
+ */
+export function useTaskManagement(_workspaceId: string = "demo", _isOnlineMode: boolean = false) {
+  const [tasks, setTasks] = useState(INITIAL_TASKS);
+
+  const handleTaskSave = useCallback(async (task: KanbanCardProps, isNewTask: boolean, newTaskColumn: string) => {
+    const targetColumn = isNewTask ? newTaskColumn : task.status;
+    
+    setTasks(prev => {
+      const newTasks = { ...prev };
+      
+      if (isNewTask) {
+        newTasks[targetColumn] = [...(newTasks[targetColumn] || []), task];
+      } else {
+        Object.keys(newTasks).forEach(columnId => {
+          newTasks[columnId] = newTasks[columnId].map(t => 
+            t.id === task.id ? task : t
+          );
+        });
+      }
+      
+      return newTasks;
+    });
+  }, []);
+
+  const handleTaskMove = useCallback(async (taskId: string, newStatus: TaskStatus) => {
+    setTasks(prev => {
+      const newTasks = { ...prev };
+      let taskToMove: KanbanCardProps | null = null;
+      
+      Object.keys(newTasks).forEach(columnId => {
+        const taskIndex = newTasks[columnId].findIndex(t => t.id === taskId);
+        if (taskIndex !== -1) {
+          taskToMove = { ...newTasks[columnId][taskIndex], status: newStatus };
+          newTasks[columnId] = newTasks[columnId].filter(t => t.id !== taskId);
+        }
+      });
+      
+      if (taskToMove) {
+        newTasks[newStatus] = [...(newTasks[newStatus] || []), taskToMove];
+      }
+      
+      return newTasks;
+    });
+  }, []);
+
+  const handleStatusChange = useCallback((taskId: string, newStatus: TaskStatus) => {
+    handleTaskMove(taskId, newStatus);
+  }, [handleTaskMove]);
+
+  return {
+    tasks,
+    isLoading: false,
+    error: null,
+    handleTaskSave,
+    handleTaskMove,
+    handleStatusChange,
+  };
+}

--- a/src/hooks/workspace/useWorkspaceState.ts
+++ b/src/hooks/workspace/useWorkspaceState.ts
@@ -1,0 +1,63 @@
+// 표준 라이브러리
+import { useState, useCallback } from "react";
+
+// 내부 타입
+import type { KanbanCardProps, TaskStatus } from "@/components/workspace/KanbanCard";
+
+/**
+ * 워크스페이스 상태 관리 커스텀 훅
+ * 태스크, 뷰, 상세 패널 등 워크스페이스의 전체적인 상태를 관리합니다.
+ */
+export function useWorkspaceState() {
+  const [activeView, setActiveView] = useState<"kanban" | "calendar" | "documents">("kanban");
+  const [selectedTask, setSelectedTask] = useState<KanbanCardProps | null>(null);
+  const [isDetailExpanded, setIsDetailExpanded] = useState(false);
+  const [isNewTask, setIsNewTask] = useState(false);
+  const [newTaskColumn, setNewTaskColumn] = useState<TaskStatus>("todo");
+  
+  const handleTaskSelect = useCallback((task: KanbanCardProps) => {
+    setSelectedTask(task);
+    setIsNewTask(false);
+    setIsDetailExpanded(false);
+  }, []);
+
+  const handleNewTask = useCallback((columnId: TaskStatus) => {
+    setNewTaskColumn(columnId);
+    setIsNewTask(true);
+    setSelectedTask(null);
+    setIsDetailExpanded(false);
+  }, []);
+
+  const handleCloseTaskDetail = useCallback(() => {
+    setSelectedTask(null);
+    setIsNewTask(false);
+    setIsDetailExpanded(false);
+  }, []);
+
+  const handleExpandDetail = useCallback(() => {
+    setIsDetailExpanded(prev => !prev);
+  }, []);
+
+  const handleViewChange = useCallback((view: "kanban" | "calendar" | "documents") => {
+    setActiveView(view);
+  }, []);
+
+  return {
+    // State
+    activeView,
+    selectedTask,
+    isDetailExpanded,
+    isNewTask,
+    newTaskColumn,
+    
+    // Computed
+    isShowDetail: selectedTask !== null || isNewTask,
+    
+    // Handlers
+    handleTaskSelect,
+    handleNewTask,
+    handleCloseTaskDetail,
+    handleExpandDetail,
+    handleViewChange,
+  };
+}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -1,0 +1,120 @@
+// 표준 라이브러리
+import { useState } from "react";
+
+// 서드파티 라이브러리
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
+// 내부 컴포넌트
+import { WorkspaceSidebar } from "@/components/workspace/WorkspaceSidebar";
+import { KanbanBoard } from "@/components/workspace/KanbanBoard";
+import { CalendarView } from "@/components/workspace/CalendarView";
+import { DocumentsView } from "@/components/workspace/DocumentsView";
+import { TaskDetail } from "@/components/workspace/TaskDetail";
+
+// 내부 훅
+import { useWorkspaceState } from "@/hooks/workspace/useWorkspaceState";
+import { useTaskManagement } from "@/hooks/workspace/useTaskManagement";
+
+/**
+ * 워크스페이스 페이지 컴포넌트
+ * 프로젝트 관리를 위한 칸반 보드, 캘린더, 문서 등 다양한 뷰를 제공합니다.
+ */
+export default function WorkspacePage() {
+  // 워크스페이스 상태 관리
+  const {
+    activeView,
+    selectedTask,
+    isDetailExpanded,
+    isNewTask,
+    newTaskColumn,
+    isShowDetail,
+    handleTaskSelect,
+    handleNewTask,
+    handleCloseTaskDetail,
+    handleExpandDetail,
+    handleViewChange,
+  } = useWorkspaceState();
+
+  // 태스크 관리 (데모용 오프라인 모드)
+  const {
+    tasks,
+    isLoading,
+    error,
+    handleTaskSave: handleTaskSaveBase,
+    handleTaskMove,
+    handleStatusChange,
+  } = useTaskManagement("demo", false);
+
+  // 태스크 저장 핸들러
+  const handleTaskSave = async (task: any) => {
+    await handleTaskSaveBase(task, isNewTask, newTaskColumn);
+  };
+
+  const renderMainContent = () => {
+    switch (activeView) {
+      case "kanban":
+        return (
+          <KanbanBoard 
+            onTaskSelect={handleTaskSelect}
+            onNewTask={handleNewTask}
+            tasks={tasks}
+            onTaskMove={handleTaskMove}
+          />
+        );
+      case "calendar":
+        return <CalendarView />;
+      case "documents":
+        return <DocumentsView />;
+      default:
+        return (
+          <KanbanBoard 
+            onTaskSelect={handleTaskSelect}
+            onNewTask={handleNewTask}
+            tasks={tasks}
+            onTaskMove={handleTaskMove}
+          />
+        );
+    }
+  };
+
+  return (
+    <div className="w-full h-screen bg-gray-50">
+      <DndProvider backend={HTML5Backend}>
+        <div className="flex h-full">
+          <WorkspaceSidebar activeView={activeView} onViewChange={handleViewChange} />
+          
+          <div className="flex flex-1 overflow-hidden">
+            {!isDetailExpanded && (
+              <main className="flex-1 overflow-hidden">
+                {isLoading ? (
+                  <div className="flex items-center justify-center h-full">
+                    <div className="text-lg text-gray-600">데이터를 불러오는 중...</div>
+                  </div>
+                ) : error ? (
+                  <div className="flex items-center justify-center h-full">
+                    <div className="text-lg text-red-600">데이터 로드 중 오류가 발생했습니다.</div>
+                  </div>
+                ) : (
+                  renderMainContent()
+                )}
+              </main>
+            )}
+            
+            {isShowDetail && (
+              <TaskDetail 
+                task={selectedTask}
+                isExpanded={isDetailExpanded}
+                isNewTask={isNewTask}
+                onClose={handleCloseTaskDetail}
+                onExpand={handleExpandDetail}
+                onSave={handleTaskSave}
+                onStatusChange={handleStatusChange}
+              />
+            )}
+          </div>
+        </div>
+      </DndProvider>
+    </div>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -3,6 +3,7 @@ import PostPage from "./pages/PostPage";
 import PostDetailPage from "./pages/PostDetailPage";
 import UserPage from "./pages/UserPages";
 import UserDetailPages from "./pages/UserDetailPages";
+import WorkspacePage from "./pages/WorkspacePage";
 import { MyPage } from "./pages/MyPage";
 import { AuthGuard } from "./utils/AuthGuard";
 
@@ -12,6 +13,7 @@ export const AppRoutes = () => (
     <Route path="/post/detail/:id" element={<PostDetailPage />} />
     <Route path="/user" element={<UserPage />} />
     <Route path="/user/detail/:id" element={<UserDetailPages />} />
+    <Route path="/workspace" element={<WorkspacePage />} />
     <Route
       path="/mypage"
       element={

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,11 @@
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
 
+"@babel/runtime@^7.9.2":
+  version "7.28.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.3.tgz#75c5034b55ba868121668be5d5bb31cc64e6e61a"
+  integrity sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==
+
 "@babel/template@^7.27.2", "@babel/template@^7.3.3":
   version "7.27.2"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz"
@@ -1130,6 +1135,21 @@
   version "0.2.7"
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz"
   integrity sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==
+
+"@react-dnd/asap@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
+  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
+
+"@react-dnd/invariant@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
+  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
+
+"@react-dnd/shallowequal@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
+  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
 
 "@rolldown/pluginutils@1.0.0-beta.11":
   version "1.0.0-beta.11"
@@ -3082,6 +3102,15 @@ dlv@^1.1.3:
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dnd-core@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
+  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
+  dependencies:
+    "@react-dnd/asap" "^5.0.1"
+    "@react-dnd/invariant" "^4.0.1"
+    redux "^4.2.0"
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz"
@@ -3856,7 +3885,7 @@ headers-polyfill@^4.0.2:
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz#922a0155de30ecc1f785bcf04be77844ca95ad07"
   integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -4823,6 +4852,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lucide-react@^0.541.0:
+  version "0.541.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.541.0.tgz#17f8b9a3b74e1c1665801c42964c7cfe7e77342d"
+  integrity sha512-s0Vircsu5WaGv2KoJZ5+SoxiAJ3UXV5KqEM3eIFDHaHkcLIFdIWgXtZ412+Gh02UsdS7Was+jvEpBvPCWQISlg==
+
 magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz"
@@ -5400,6 +5434,24 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
+react-dnd@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
+  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    "@react-dnd/shallowequal" "^4.0.1"
+    dnd-core "^16.0.1"
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+
 react-dom@^19.1.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz"
@@ -5455,6 +5507,13 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redux@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"


### PR DESCRIPTION
  ## Summary
  • 워크스페이스 페이지 구현 - 드래그 앤 드롭 기반 프로젝트 관리 인터페이스
  • 새로운 atomic 컴포넌트 추가 - Avatar, Card 컴포넌트로 재사용성 향상
  • 워크스페이스 전용 hooks 및 컴포넌트 모듈 구축

  ## Changes
  - **Dependencies**: lucide-react, react-dnd, react-dnd-html5-backend 추가
  - **Components**: Avatar, Card atomic 컴포넌트 및 workspace 모듈 구현
  - **Routing**: `/workspace` 경로 추가 및 헤더 메뉴 네비게이션 연결
  - **Hooks**: 워크스페이스 관련 비즈니스 로직을 위한 custom hooks

  ## Test plan
  - [ ] 워크스페이스 페이지 접근 및 렌더링 확인
  - [ ] 헤더 메뉴에서 워크스페이스 링크 동작 확인
  - [ ] 드래그 앤 드롭 기능 테스트
  - [ ] 새로운 Avatar, Card 컴포넌트 스타일링 검증        
  - [ ] 모든 기존 기능 정상 동작 확인